### PR TITLE
implement WAL mode for SQLite

### DIFF
--- a/wp-content/db.php
+++ b/wp-content/db.php
@@ -4900,4 +4900,5 @@ namespace {
     }
 
     $GLOBALS['wpdb'] = new WP_SQLite_DB\wpsqlitedb();
+    $GLOBALS['wpdb']->query('PRAGMA journal_mode = wal;');
 }


### PR DESCRIPTION
As mentioned in #1, write-ahead logging (a.k.a. WAL mode) can and probably should be enabled by default for using SQLite with Wordpress.